### PR TITLE
Fix decode test for Go 1.8

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -551,7 +551,7 @@ var unmarshalTests = []struct {
 	},
 	{
 		"a: 2015-02-24T18:19:39Z\n",
-		map[string]time.Time{"a": time.Unix(1424801979, 0)},
+		map[string]time.Time{"a": time.Unix(1424801979, 0).In(time.UTC)},
 	},
 
 	// Encode empty lists as zero-length slices.


### PR DESCRIPTION
An upstream change (http://golang.org/cl/31144) alters the time package
to be more consistent about the representation of UTC location.
We adjust the time.Time used in the test to work on both 1.7 and 1.8.